### PR TITLE
Allow time skew on iat checks as well

### DIFF
--- a/jwt_signed/callout/src/test/java/com/apigee/testng/tests/TestBasicJwtParse.java
+++ b/jwt_signed/callout/src/test/java/com/apigee/testng/tests/TestBasicJwtParse.java
@@ -722,4 +722,94 @@ public class TestBasicJwtParse {
             Assert.assertEquals(isValid,"false");
         }
     }
+
+
+    @Test()
+    public void test10_NotValidYetJWT() {
+
+        String[] cases = new String[] { null, "true", "false" };
+        for(String continueOnErrorString : cases) {
+            ExecutionResult expectedResult = ("true".equals(continueOnErrorString)) ?
+                    ExecutionResult.SUCCESS : ExecutionResult.ABORT ;
+
+            Map properties = new HashMap();
+            properties.put("algorithm", "RS256");
+            properties.put("jwt", jwtMap.get("ms1"));
+            properties.put("currentTime", "1452661530000");
+            properties.put("certificate", certMap.get("ms1"));
+            if (continueOnErrorString!=null) {
+                properties.put("continueOnError", continueOnErrorString);
+            }
+
+            JwtParserCallout callout = new JwtParserCallout(properties);
+            ExecutionResult result = callout.execute(msgCtxt, exeCtxt);
+
+            // retrieve output
+            String isValid = msgCtxt.getVariable("jwt_isValid");
+            String reason = msgCtxt.getVariable("jwt_reason");
+            String hasExpiry = msgCtxt.getVariable("jwt_hasExpiry");
+            String isExpired = msgCtxt.getVariable("jwt_isExpired");
+            String isActuallyExpired = msgCtxt.getVariable("jwt_isActuallyExpired");
+
+            // check result and output
+            Assert.assertEquals(result, expectedResult);
+            Assert.assertEquals(isValid, "false");
+            Assert.assertEquals(hasExpiry, "true");
+            Assert.assertEquals(isActuallyExpired, "false");
+            Assert.assertEquals(isExpired, "false");
+            Assert.assertEquals(reason, "issuedAt is in the future");
+        }
+    }
+
+    @Test()
+    public void test10_NotValidYetJWTButWithinTimeAllowance() {
+        Map properties = new HashMap();
+        properties.put("algorithm", "RS256");
+        properties.put("jwt", jwtMap.get("ms1"));
+        properties.put("currentTime", "1452661530000");
+        properties.put("timeAllowance", "10000");
+        properties.put("certificate", certMap.get("ms1"));
+
+        JwtParserCallout callout = new JwtParserCallout(properties);
+        ExecutionResult result = callout.execute(msgCtxt, exeCtxt);
+
+        // retrieve output
+        String isValid = msgCtxt.getVariable("jwt_isValid");
+        String hasExpiry = msgCtxt.getVariable("jwt_hasExpiry");
+        String isExpired = msgCtxt.getVariable("jwt_isExpired");
+        String isActuallyExpired = msgCtxt.getVariable("jwt_isActuallyExpired");
+
+        // check result and output
+        Assert.assertEquals(result, ExecutionResult.SUCCESS);
+        Assert.assertEquals(isValid, "true");
+        Assert.assertEquals(hasExpiry, "true");
+        Assert.assertEquals(isActuallyExpired, "false");
+        Assert.assertEquals(isExpired, "false");
+    }
+
+    @Test()
+    public void test10_NotValidYetJWTButTimeCheckDisabled() {
+        Map properties = new HashMap();
+        properties.put("algorithm", "RS256");
+        properties.put("jwt", jwtMap.get("ms1"));
+        properties.put("currentTime", "1452661530000");
+        properties.put("timeAllowance", "-1");
+        properties.put("certificate", certMap.get("ms1"));
+
+        JwtParserCallout callout = new JwtParserCallout(properties);
+        ExecutionResult result = callout.execute(msgCtxt, exeCtxt);
+
+        // retrieve output
+        String isValid = msgCtxt.getVariable("jwt_isValid");
+        String hasExpiry = msgCtxt.getVariable("jwt_hasExpiry");
+        String isExpired = msgCtxt.getVariable("jwt_isExpired");
+        String isActuallyExpired = msgCtxt.getVariable("jwt_isActuallyExpired");
+
+        // check result and output
+        Assert.assertEquals(result, ExecutionResult.SUCCESS);
+        Assert.assertEquals(isValid, "true");
+        Assert.assertEquals(hasExpiry, "true");
+        Assert.assertEquals(isActuallyExpired, "false");
+        Assert.assertEquals(isExpired, "false");
+    }    
 }


### PR DESCRIPTION
While there is an option to allow for a time skew on nbf and exp checks, there is no such option for checks on the issued at time, which is also a check that cannot be disabled at all. This PR includes the following changes:

* Do the same time skew checks that are done on nbf and exp for iat as well
* Disabling time checks will also disable the check on iat checks
* Add a reason in case the jwt is deemed invalid because it was used before the issue time (saves a lot of debugging time)
* Allow the current time to be set from the properties (useful for testing)